### PR TITLE
improvements to preemptible killer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@
 # ignore build and helm artifacts
 /estafette-gke-preemptible-killer
 /estafette-gke-preemptible-killer-*.tgz
+
+# IDEs
+.idea

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,14 @@
-FROM scratch
+FROM circleci/golang:1.14 as build
 
-LABEL maintainer="estafette.io" \
-      description="The estafette-gke-preemptible-killer component is a Kubernetes controller that ensures preemptible nodes in a Container Engine cluster don't expire at the same time"
+COPY . /home/circleci/gke-preemp-killer
 
-COPY ca-certificates.crt /etc/ssl/certs/
-COPY estafette-gke-preemptible-killer /
+WORKDIR /home/circleci/gke-preemp-killer
 
-CMD ["./estafette-gke-preemptible-killer"]
+RUN go build -v -o /tmp/gke-preemp-killer *.go &&\
+    chmod +x /tmp/gke-preemp-killer
+
+FROM gcr.io/pendo-dev/base-runtime:latest
+
+COPY --from=build /tmp/gke-preemp-killer /opt/gke-preemp-killer
+
+ENTRYPOINT ["/opt/gke-preemp-killer"]

--- a/README.md
+++ b/README.md
@@ -21,10 +21,6 @@ deleted on GCloud.
 
 ## Known limitations
 
-- Pods in selected nodes are deleted, not evicted.
-- Currently deletion time is based on node creation time, so if you deploy
-  this tool when your instances have over 12h then you may experience a lot
-  of nodes getting deleted at once.
 - Selecting node pool is not supported yet, the code is processing ALL
   preemptible nodes attached to the cluster, and there is no way to limit it
   even via taints nor annotations

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/estafette/estafette-gke-preemptible-killer
 
-go 1.12
+go 1.14
 
 require (
 	github.com/alecthomas/assert v0.0.0-20170929043011-405dbfeb8e38 // indirect

--- a/helm/estafette-gke-preemptible-killer/templates/clusterrole.yaml
+++ b/helm/estafette-gke-preemptible-killer/templates/clusterrole.yaml
@@ -19,7 +19,11 @@ rules:
   resources:
   - pods
   verbs:
-  - delete
   - get
   - list
+- apiGroups: [""] # "" indicates the core API group
+  resources:
+  - pods/eviction
+  verbs:
+  - create
 {{- end -}}

--- a/helm/estafette-gke-preemptible-killer/values.yaml
+++ b/helm/estafette-gke-preemptible-killer/values.yaml
@@ -14,7 +14,7 @@ interval: 300
 
 secret:
   # if set to true the values are already base64 encoded when provided, otherwise the template performs the base64 encoding
-  valuesAreBase64Encoded: false
+  valuesAreBase64Encoded: true
 
   # when using estafette-gcp-service account controller to fetch key files, set this to true and leave googleServiceAccountKeyfileJson empty
   useGcpServiceAccountAnnotation: false
@@ -35,7 +35,7 @@ logFormat: plaintext
 replicaCount: 1
 
 image:
-  repository: estafette/estafette-gke-preemptible-killer
+  repository: setme
   # The tag can be set to override the appVersion getting used as the image tag
   tag:
   pullPolicy: IfNotPresent


### PR DESCRIPTION
-  evict pods from nodes instead of direct deletion
- node deletion time should not be marked in the past
- fix resource leaks where goroutines may run forever